### PR TITLE
fix: 문법 에러

### DIFF
--- a/Language/[Javascript] ES2015+ 요약 정리.md
+++ b/Language/[Javascript] ES2015+ 요약 정리.md
@@ -59,7 +59,7 @@ const c; // error
 ```javascript
 var string = num1 + ' + ' + num2 + ' = ' + result;
 
-const string = ${num1} + ${num2} = ${result};
+const string = `${num1} + ${num2} = ${result}`;
 ```
 
 <br>


### PR DESCRIPTION
JS 백틱 설명란에 문자열이 백틱으로 되어있지 않은 것을 발견했습니다.