### PR TITLE
2020-12-28 [Algorithm] QuickSort 코드수정

### DIFF
--- a/Algorithm/QuickSort.md
+++ b/Algorithm/QuickSort.md
@@ -112,7 +112,7 @@ public static int partition(int[] array, int left, int right) {
     int mid = (left + right) / 2;
     swap(array, left, mid);
  
-    int pivot = array[mid];
+    int pivot = array[left];
     int i = left, j = right;
  
     while (i < j) {


### PR DESCRIPTION
partition함수 안에서 Mid값을 pivot 으로 정하기 위해서 swap(arr, left, mid) 호출로 left와 mid의 값을 바꾸지만 pivot = array[mid]를 하게되면 결국 left값이 pivot으로 선택되어 128,129 번째 줄에서 값을 바꿨을 때 원하지 않는 값들이 바뀌어 숫자들이 이상해집니다.

추가로
이전 #93 PR에서 이부분의 오탈자를 변경한걸로 보이는데
```java
int mid = (left+right)/2;
swap(arr, left, mid);
```
앞서 swap을 하기 때문에 arr[left]가 맞는 답으로 보입니다 ^^!

참고를 위해 출력했을 때 답을 사진으로 넣어놓겠습니다.

### 코드 바꾸기전 출력 답
![오답](https://user-images.githubusercontent.com/41230031/103212365-eba99100-494d-11eb-87e9-891d80a33946.JPG)

### 코드 변경 후 출력 답
![답](https://user-images.githubusercontent.com/41230031/103212368-ecdabe00-494d-11eb-809f-e6e897d9e1b7.JPG)