### PR TITLE
Fix content error

### DIFF
--- a/Computer Science/Operating System/CPU Scheduling.md
+++ b/Computer Science/Operating System/CPU Scheduling.md
@@ -20,8 +20,8 @@
 ### 3. 프로세스 상태
 
 ![download (5)](https://user-images.githubusercontent.com/13609011/91695344-f2dfae80-eba8-11ea-9a9b-702192316170.jpeg)
-- 비선점 스케줄링 : `Interrupt`, `Scheduler Dispatch`
-- 선점 스케줄링 : `I/O or Event Wait`
+- 선점 스케줄링 : `Interrupt`, `I/O or Event Completion`, `I/O or Event Wait`, `Exit`
+- 비선점 스케줄링 : `I/O or Event Wait`, `Exit`
 
 ---
 


### PR DESCRIPTION
기존에 선점형과 비선점형의 예시가 둘이 바뀌었고, 이해를 돕기 위해 스케줄링이 발생하는 모든 상황을 예시에 추가하였습니다. 그 근거는 공룡책과 기존 사진의 내용을 토대로 다음과 같습니다.

![process state diagram](https://user-images.githubusercontent.com/13609011/91695344-f2dfae80-eba8-11ea-9a9b-702192316170.jpeg)

- CPU의 스케줄링이 일어날 수 있는 프로세스 상태 전이는 4가지 이다.
  + `I/O or Event wait`
  + `I/O or Event completion`
  + `Interrupt`
  + `Exit`

- 비선점형 스케줄링은 `I/O or Event wait` 혹은 `Exit` 에서만 발생한다.
- 선점형 스케줄링은 4가지 경우 모두에서 발생한다.