### PR TITLE
fix lexical scope js example to print

### DIFF
--- a/Language/[Javascript] Closure.md
+++ b/Language/[Javascript] Closure.md
@@ -24,6 +24,7 @@ function func() {
     function func2() {
         console.log(x);
     }
+    func2();
 }
 
 func() // print 5


### PR DESCRIPTION
예제 코드에서 함수 실행이 빠져 출력이 안되던 점을 수정했습니다.